### PR TITLE
Add internal domain resolution for your own dyndns domain

### DIFF
--- a/build/bind/dappnode.io.hosts
+++ b/build/bind/dappnode.io.hosts
@@ -1,0 +1,9 @@
+$TTL    3600
+@       IN      SOA     dyndns.dappnode.io. root.dyndns.dappnode.io.(
+                   2007010401           ; Serial
+                         3600           ; Refresh [1h]
+                          600           ; Retry   [10m]
+                        86400           ; Expire  [1d]
+                          600 )         ; Negative Cache TTL [1h]
+;
+@       IN      NS      dyndns.dappnode.io.

--- a/build/bind/default.hosts
+++ b/build/bind/default.hosts
@@ -1,0 +1,13 @@
+zone "." IN {
+		type hint;
+		file "named.ca";
+};
+zone "eth" {
+    in-view "dappmanager";
+};
+zone "dappnode" {
+    in-view "dappmanager";
+};
+zone "test" {
+    in-view "dappmanager";
+};

--- a/build/bind/named.conf
+++ b/build/bind/named.conf
@@ -40,7 +40,8 @@ options {
 	allow-transfer { none; };
 	allow-query { any; };
 	allow-new-zones yes;
-
+	dnssec-validation yes;
+	dnssec-enable yes;
 };
 
 acl wifi_dnp { 

--- a/build/bind/named.conf
+++ b/build/bind/named.conf
@@ -1,12 +1,21 @@
 logging {
-    channel stdout {
+	channel stdout {
 		stderr;
-        severity dynamic;
-        print-time yes;
-    };
-  category general {
-    stdout;
-  };
+		severity dynamic;
+		print-time yes;
+	};
+	category general {
+		stdout;
+	};
+};
+
+key "rndc-key" {
+	algorithm hmac-sha256;
+ 	secret "8iFQ835rdmRdxEJaIFIJDpata5mL6kYFncd6F9Mn150=";
+};
+ 
+controls {
+ 	inet 0.0.0.0 port 953 allow { 172.33.1.7; } keys { "rndc-key"; };
 };
 
 options {
@@ -30,35 +39,74 @@ options {
 
 	allow-transfer { none; };
 	allow-query { any; };
+	allow-new-zones yes;
+
 };
 
-zone "." IN {
-	type hint;
-	file "named.ca";
+acl wifi_dnp { 
+	172.33.1.10; 
+	172.33.10.0/24; 
 };
 
-zone "localhost" IN {
-	type master;
-	file "pri/localhost.zone";
-	allow-update { none; };
-	notify no;
+acl vpn_clients {
+	172.33.10.0/24; 
 };
 
-zone "127.in-addr.arpa" IN {
-	type master;
-	file "pri/127.zone";
-	allow-update { none; };
-	notify no;
+acl dappmanager { 
+	172.33.1.7/32; 
 };
 
-zone "eth" {
-	type master;
-	file "/etc/bind/eth.hosts";
-	allow-update { 172.33.1.7; };
+view dappmanager {
+	match-clients { dappmanager; };
+	allow-recursion { any; };
+
+	zone "." IN {
+		type hint;
+		file "named.ca";
+	};
+
+	zone "localhost" IN {
+		type master;
+		file "pri/localhost.zone";
+		allow-update { none; };
+		notify no;
+	};
+
+	zone "127.in-addr.arpa" IN {
+		type master;
+		file "pri/127.zone";
+		allow-update { none; };
+		notify no;
+	};
+
+	zone "eth" {
+		type master;
+		file "/etc/bind/eth.hosts";
+		allow-update { 172.33.1.7; };
+	};
+
+	zone "dappnode" {
+		type master;
+		file "/etc/bind/dappnode.hosts";
+		allow-update { 172.33.1.7; };
+	};
+
+	zone "test" {
+		type master;
+		file "/etc/bind/test.hosts";
+		allow-update { 172.33.1.7; };
+	};
 };
 
-zone "dappnode" {
-	type master;
-	file "/etc/bind/dappnode.hosts";
-	allow-update { 172.33.1.7; };
+
+view internal_domain {
+	match-clients { wifi_dnp; vpn_clients; };
+	allow-recursion { any; };
+	include "/etc/bind/default.hosts";
+};
+
+view all {
+	match-clients { any; };
+	allow-recursion { any; };
+	include "/etc/bind/default.hosts";
 };

--- a/build/bind/rndc.conf
+++ b/build/bind/rndc.conf
@@ -1,0 +1,24 @@
+# Start of rndc.conf
+key "rndc-key" {
+	algorithm hmac-sha256;
+	secret "8iFQ835rdmRdxEJaIFIJDpata5mL6kYFncd6F9Mn150=";
+};
+
+options {
+	default-key "rndc-key";
+	default-server 127.0.0.1;
+	default-port 953;
+};
+# End of rndc.conf
+
+# Use with the following in named.conf, adjusting the allow list as needed:
+# key "rndc-key" {
+# 	algorithm hmac-sha256;
+# 	secret "8iFQ835rdmRdxEJaIFIJDpata5mL6kYFncd6F9Mn150=";
+# };
+# 
+# controls {
+# 	inet 127.0.0.1 port 953
+# 		allow { 127.0.0.1; } keys { "rndc-key"; };
+# };
+# End of named.conf

--- a/build/bind/test.hosts
+++ b/build/bind/test.hosts
@@ -1,0 +1,12 @@
+$ORIGIN .
+$TTL 38400		; 10 hours 40 minutes
+test			IN SOA	test. administrator.test. (
+				1515764902 ; serial
+				10800      ; refresh (3 hours)
+				3600       ; retry (1 hour)
+				604800     ; expire (1 week)
+				38400      ; minimum (10 hours 40 minutes)
+				)
+			NS	172.33.1.2
+$ORIGIN test.
+*			    A	172.33.1.3

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -7,6 +7,21 @@ if [ ! -f /etc/bind/dappnode.hosts ]; then
     cp /config/dappnode.hosts /etc/bind/dappnode.hosts
 fi
 
+##################
+# v0.2.1 migration
+##################
+if [ ! -f /etc/bind/dappnode.io.hosts ]; then
+    cp /config/dappnode.io.hosts /etc/bind/dappnode.io.hosts
+fi
+
+if [ ! -f /etc/bind/default.hosts ]; then
+    cp /config/default.hosts /etc/bind/default.hosts
+fi
+
+if [ ! -f /etc/bind/test.hosts ]; then
+    cp /config/test.hosts /etc/bind/test.hosts
+fi
+
 diff /etc/bind/named.conf /config/named.conf
 if [ $? -ne 0 ]; then
     cp /config/named.conf /etc/bind/named.conf


### PR DESCRIPTION
When it tries to resolve your own domain connected by Wi-Fi or VPN client, it'll return the internal IP