### PR TITLE
compose migration from 3.4 to 3.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,13 @@ services:
     container_name: DAppNodeCore-bind.dnp.dappnode.eth
     restart: always
     networks:
-      network:
+      dncore_network:
         ipv4_address: 172.33.1.2
+        aliases:
+          - bind.dappnode
     logging:
       driver: journald
 networks:
-  network:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: 172.33.0.0/16
+  dncore_network:
+    name: dncore_network
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: "3.5"
 services:
   bind.dnp.dappnode.eth:
     build: ./build

--- a/test/docker-compose-test.yml
+++ b/test/docker-compose-test.yml
@@ -7,8 +7,9 @@ services:
     container_name: Test
     dns: 172.33.1.2
     networks:
-      - dnp_bind_network
+      - dncore_network
 
 networks:
-  dnp_bind_network:
+  dncore_network:
     external: true
+    name: dncore_network

--- a/test/test.sh
+++ b/test/test.sh
@@ -5,5 +5,6 @@
 # [On xenial]:
 #   The name of the folder is DNP_BIND and the network dnp_bind_network
 
+docker network create --driver bridge --subnet 172.33.0.0/16 dncore_network || echo "dncore_network already exists"
 docker-compose -f docker-compose.yml up -d
 docker-compose -f test/docker-compose-test.yml run test


### PR DESCRIPTION
- Set `dncore_network` as external (will be asumme as created. The installer should create at installation https://github.com/dappnode/DAppNode_Installer/pull/98)
- Add alias

More info in https://github.com/dappnode/DNP_DAPPMANAGER/issues/655