### PR TITLE
Fix error being set into txt file

### DIFF
--- a/bind/entrypoint.sh
+++ b/bind/entrypoint.sh
@@ -19,12 +19,16 @@ fetch_env() {
         sleep $wait_time
     done
 
-    echo "Error: Failed to fetch $env_var_name after $retries attempts."
+    echo " [ERROR] Failed to fetch $env_var_name after $retries attempts."
     return 1
 }
 
 # Start DNS server in background right away
 /app/dnscrypt-proxy &
+
+# Initialize domain and internal_ip variables
+domain=""
+internal_ip=""
 
 pid=$!
 
@@ -39,9 +43,7 @@ else
     if [ $? -eq 0 ]; then
         domain=$fetched_domain
     else
-        echo "Failed to fetch DOMAIN"
-        kill $pid
-        exit 1
+        echo "[ERROR] Failed to fetch DOMAIN"
     fi
 fi
 
@@ -54,15 +56,18 @@ else
     if [ $? -eq 0 ]; then
         internal_ip=$fetched_internal_ip
     else
-        echo "Failed to fetch INTERNAL_IP"
-        kill $pid
-        exit 1
+        echo "[ERROR] Failed to fetch INTERNAL_IP"
     fi
 fi
 
-echo "$domain $internal_ip" >cloaking-rules.txt
+# Only write to cloaking-rules.txt if both domain and internal_ip are available
+if [ -n "$domain" ] && [ -n "$internal_ip" ]; then
+    echo "$domain $internal_ip" >cloaking-rules.txt
 
-kill $pid
-wait $pid
+    kill $pid
+    wait $pid
 
-/app/dnscrypt-proxy
+    /app/dnscrypt-proxy
+else
+    echo "[ERROR] Missing domain or internal IP. Cloaking rules not updated. Dyndns domain will not be forwarded to internal IP."
+fi

--- a/bind/entrypoint.sh
+++ b/bind/entrypoint.sh
@@ -20,7 +20,7 @@ fetch_env() {
     done
 
     echo "Error: Failed to fetch $env_var_name after $retries attempts."
-    exit 1
+    return 1
 }
 
 # Start DNS server in background right away
@@ -34,14 +34,30 @@ if [ -n "${_DAPPNODE_GLOBAL_DOMAIN}" ]; then
     domain=${_DAPPNODE_GLOBAL_DOMAIN}
     echo "Using existing domain: $domain"
 else
-    domain=$(fetch_env "DOMAIN")
+    fetched_domain=$(fetch_env "DOMAIN")
+
+    if [ $? -eq 0 ]; then
+        domain=$fetched_domain
+    else
+        echo "Failed to fetch DOMAIN"
+        kill $pid
+        exit 1
+    fi
 fi
 
 if [ -n "${_DAPPNODE_GLOBAL_INTERNAL_IP}" ]; then
     internal_ip=${_DAPPNODE_GLOBAL_INTERNAL_IP}
     echo "Using existing domain: $domain"
 else
-    internal_ip=$(fetch_env "INTERNAL_IP")
+    fetched_internal_ip=$(fetch_env "INTERNAL_IP")
+
+    if [ $? -eq 0 ]; then
+        internal_ip=$fetched_internal_ip
+    else
+        echo "Failed to fetch INTERNAL_IP"
+        kill $pid
+        exit 1
+    fi
 fi
 
 echo "$domain $internal_ip" >cloaking-rules.txt


### PR DESCRIPTION
When attempts failed when trying to fetch both the domain or the internal IP, these errors ended up being written into the file `cloacking-rules.txt`