### PR TITLE
Fix cloaking rules file

### DIFF
--- a/bind/Dockerfile
+++ b/bind/Dockerfile
@@ -24,7 +24,7 @@ FROM alpine:3.18
 
 WORKDIR /app
 
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl jq
 
 COPY --from=builder /usr/local/bin/dnscrypt-proxy /app/dnscrypt-proxy
 

--- a/bind/entrypoint.sh
+++ b/bind/entrypoint.sh
@@ -4,11 +4,10 @@
 fetch_env() {
     local env_var_name=$1
     local env_var_value=""
-    local retries=30  # Number of retries
-    local wait_time=1 # Wait time between retries
+    local wait_time=10 # Wait time between retries
 
-    for i in $(seq 1 $retries); do
-        echo "Fetching $env_var_name (attempt $i)"
+    while true; do
+        echo "Fetching $env_var_name"
         env_var_value=$(curl -s "my.dappnode/global-envs/$env_var_name")
 
         if [ -n "$env_var_value" ]; then
@@ -18,9 +17,6 @@ fetch_env() {
 
         sleep $wait_time
     done
-
-    echo " [ERROR] Failed to fetch $env_var_name after $retries attempts."
-    return 1
 }
 
 # Start DNS server in background right away
@@ -39,12 +35,7 @@ if [ -n "${_DAPPNODE_GLOBAL_DOMAIN}" ]; then
     echo "Using existing domain: $domain"
 else
     fetched_domain=$(fetch_env "DOMAIN" | tail -n 1)
-
-    if [ $? -eq 0 ]; then
-        domain=$fetched_domain
-    else
-        echo "[ERROR] Failed to fetch DOMAIN"
-    fi
+    domain=$fetched_domain
 fi
 
 if [ -n "${_DAPPNODE_GLOBAL_INTERNAL_IP}" ]; then
@@ -52,12 +43,7 @@ if [ -n "${_DAPPNODE_GLOBAL_INTERNAL_IP}" ]; then
     echo "Using existing internal IP: $internal_ip"
 else
     fetched_internal_ip=$(fetch_env "INTERNAL_IP" | tail -n 1)
-
-    if [ $? -eq 0 ]; then
-        internal_ip=$fetched_internal_ip
-    else
-        echo "[ERROR] Failed to fetch INTERNAL_IP"
-    fi
+    internal_ip=$fetched_internal_ip
 fi
 
 # Only write to cloaking-rules.txt if both domain and internal_ip are available

--- a/bind/entrypoint.sh
+++ b/bind/entrypoint.sh
@@ -38,7 +38,7 @@ if [ -n "${_DAPPNODE_GLOBAL_DOMAIN}" ]; then
     domain=${_DAPPNODE_GLOBAL_DOMAIN}
     echo "Using existing domain: $domain"
 else
-    fetched_domain=$(fetch_env "DOMAIN")
+    fetched_domain=$(fetch_env "DOMAIN" | tail -n 1)
 
     if [ $? -eq 0 ]; then
         domain=$fetched_domain
@@ -49,9 +49,9 @@ fi
 
 if [ -n "${_DAPPNODE_GLOBAL_INTERNAL_IP}" ]; then
     internal_ip=${_DAPPNODE_GLOBAL_INTERNAL_IP}
-    echo "Using existing domain: $domain"
+    echo "Using existing internal IP: $internal_ip"
 else
-    fetched_internal_ip=$(fetch_env "INTERNAL_IP")
+    fetched_internal_ip=$(fetch_env "INTERNAL_IP" | tail -n 1)
 
     if [ $? -eq 0 ]; then
         internal_ip=$fetched_internal_ip

--- a/bind/entrypoint.sh
+++ b/bind/entrypoint.sh
@@ -14,7 +14,7 @@ fetch_envs() {
     local wait_time=10 # Wait time between retries
 
     while true; do
-        response=$(curl -s http://dappmanager.dappnode/global-envs) # Replace with actual API endpoint if different
+        response=$(curl -s http://dappmanager.dappnode/global-envs)
 
         if [ $? -eq 0 ]; then
             domain=$(echo $response | jq -r '.DOMAIN')

--- a/bind/entrypoint.sh
+++ b/bind/entrypoint.sh
@@ -14,7 +14,7 @@ fetch_envs() {
     local wait_time=10 # Wait time between retries
 
     while true; do
-        response=$(curl -s http://dappmanager-api/global-envs) # Replace with actual API endpoint if different
+        response=$(curl -s http://dappmanager.dappnode/global-envs) # Replace with actual API endpoint if different
 
         if [ $? -eq 0 ]; then
             domain=$(echo $response | jq -r '.DOMAIN')
@@ -24,7 +24,7 @@ fetch_envs() {
                 break
             fi
         else
-            echo "Failed to fetch data. Retrying in $wait_time seconds..."
+            echo "[ERROR] Failed to fetch data. Retrying in $wait_time seconds..."
         fi
 
         sleep $wait_time
@@ -36,8 +36,9 @@ if [ -n "${_DAPPNODE_GLOBAL_DOMAIN}" ] && [ -n "${_DAPPNODE_GLOBAL_INTERNAL_IP}"
     domain=${_DAPPNODE_GLOBAL_DOMAIN}
     internal_ip=${_DAPPNODE_GLOBAL_INTERNAL_IP}
 
-    echo "Using domain($domain) and internal ip ($internal_ip) from global envs."
+    echo "[INFO] Using domain($domain) and internal ip ($internal_ip) from global envs."
 else
+    echo "[INFO] Fetching domain and internal ip from Dappmanager API..."
     fetch_envs
 fi
 
@@ -50,5 +51,6 @@ if [ -n "$domain" ] && [ -n "$internal_ip" ]; then
 
     /app/dnscrypt-proxy
 else
+    touch cloaking-rules.txt
     echo "[ERROR] Missing domain or internal IP. Cloaking rules not updated. Dyndns domain will not be forwarded to internal IP."
 fi


### PR DESCRIPTION
The file `cloaking-rules.txt` ended up being full of logs that should not be part of the input to the file. Example:

```
Fetching DOMAIN (attempt 1)
Fetching DOMAIN (attempt 2)
Fetching DOMAIN (attempt 3)
Fetching DOMAIN (attempt 4)
Fetching DOMAIN (attempt 5)
Fetching DOMAIN (attempt 6)
Fetching DOMAIN (attempt 7)
Fetching DOMAIN (attempt 8)
Fetching DOMAIN (attempt 9)
Fetching DOMAIN (attempt 10)
Fetching DOMAIN (attempt 11)
Fetching DOMAIN (attempt 12)
Fetching DOMAIN (attempt 13)
Fetching DOMAIN (attempt 14)
Fetching DOMAIN (attempt 15)
Fetching DOMAIN (attempt 16)
Fetching DOMAIN (attempt 17)
Fetching DOMAIN (attempt 18)
Fetching DOMAIN (attempt 19)
Fetching DOMAIN (attempt 20)
Fetching DOMAIN (attempt 21)
Fetching DOMAIN (attempt 22)
xxxxxxxxxxx.dyndns.dappnode.io Fetching INTERNAL_IP (attempt 1)
192.168.1.65
```

This PR fixes it.