### PR TITLE
Add `dappnode.private` to forwarding rules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - run: docker-compose build
+      - run: docker compose build
 
   release:
     name: Release

--- a/bind/custom/config/forwarding-rules.txt
+++ b/bind/custom/config/forwarding-rules.txt
@@ -1,2 +1,3 @@
 dappnode 127.0.0.11
+dappnode.private 127.0.0.11
 eth 127.0.0.11 my.dappnode


### PR DESCRIPTION
Add `dappnode.private` to forwarding rules. Needed by `dnprivate_network` docker aliases